### PR TITLE
ACP2E-1124: Remove "will be released with 2.4.5" callout at the new integration test devdocs section

### DIFF
--- a/src/pages/guide/integration/annotations/index.md
+++ b/src/pages/guide/integration/annotations/index.md
@@ -10,7 +10,7 @@ DocBlock annotations help to declare context in your code. In addition to built-
 
 <InlineAlert variant="info" slots="text" />
 
-Native PHP8 Attributes can be used instead or together with DocBlock annotations. This new method offers more flexibility and improves readability of the code. See the [Attributes](../attributes/index.md) to learn more. This feature is currently only available for Magento Open Source contributors. It will be released for general use with Magento Open Source 2.4.5.
+Native PHP8 Attributes can be used instead or together with DocBlock annotations. This new method offers more flexibility and improves readability of the code. See the [Attributes](../attributes/index.md) to learn more.
 
 ### Quick overview
 

--- a/src/pages/guide/integration/attributes/index.md
+++ b/src/pages/guide/integration/attributes/index.md
@@ -7,11 +7,6 @@ description: Declare context in your Adobe Commerce and Magento Open Source code
 
 [PHP built-in attributes][] help to declare context in your code. Attributes can be used alone or together with Annotations to help to declare context in your code.
 
-<InlineAlert variant="info" slots="text" />
-
-PHP built-in attributes are currently available to Magento Open Source contributors only. They will be released for general use with Magento Open Source 2.4.5.
-[PHPUnit annotations][] are still available for use with Magento Open Source.
-
 ## Quick overview
 
 The following attributes are available in integration tests:


### PR DESCRIPTION
## Purpose of this pull request

<!--- Describe your changes in detail -->

This pull request (PR) is to remove the callout the PHP8 native attributes in the integration test framework will be available with the 2.4.5 release, since 2.4.5 has been released already.

## Affected pages

<!-- REQUIRED List the pages/URLs on the [Adobe devsite](https://developer.adobe.com/. Not needed for large numbers of files. -->

- https://developer.adobe.com/commerce/testing/guide/integration/annotations/
- https://developer.adobe.com/commerce/testing/guide/integration/attributes/

## Links to related PRs or Jira tickets

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. Add links to PRs/tickets that required documentation updates -->

- https://jira.corp.adobe.com/browse/ACP2E-1124

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`
`beta` is the default branch. Merged pull requests to `main` go live on the site automatically.
See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My changes follow the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests passed.
