### PR TITLE
COMDOX-588: Standardized README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,43 @@
-# Adobe I/O Documentation Template
+# Adobe Commerce Developer Documentation
 
-This is a site template built with the [Adobe I/O Theme](https://github.com/adobe/aio-theme).
+Welcome! This site contains the latest Adobe Commerce and Magento Open Source developer documentation for ongoing releases of both products. For additional information, see our [Contribution Guide](https://developer.adobe.com/commerce/contributor/).
 
-View the [demo](https://adobedocs.github.io/dev-site-documentation-template/) running on Github Pages.  
+## Contributors
 
-## Where to ask for help
+Our goal is to provide the Adobe Commerce and Magento Open Source communities with comprehensive and quality technical documentation. We believe that to accomplish that goal we need experts from the community to share their knowledge with us and each other. We are thankful to all of our contributors for improving the documentation.
 
-The slack channel #adobeio-onsite-onboarding is our main point of contact for help. Feel free to join the channel and ask any questions. 
+![Commerce contributors](https://raw.githubusercontent.com/wiki/magento/magento2/images/dev_docs_contributors.png)
 
-## How to develop
+## Local development
 
-For local development, simply use :
-```
-$ npm install
-$ npm run dev
-```
+This is a [Gatsby](https://www.gatsbyjs.com/) project that uses the [Adobe I/O Theme](https://github.com/adobe/aio-theme).
 
-For the documentation developer, please read these sections on how to:
-- [Arrange the structure content of your docs](https://github.com/adobe/aio-theme#content-structure)
+To build the site locally:
+
+1. Clone this repo.
+1. Install project dependencies.
+
+   ```bash
+   yarn install
+   ```
+
+1. Launch the project in development mode.
+
+   ```bash
+   yarn dev
+   ```
+
+## Resources
+
+See the following resources to learn more about using the theme:
+
+- [Arranging content structure](https://github.com/adobe/aio-theme#content-structure)
 - [Linking to pages](https://github.com/adobe/aio-theme#links)
-- [Using assets](https://github.com/adobe/aio-theme-aio#assets)
-- [Setting Global Navigation](https://github.com/adobe/aio-theme#global-navigation)
-- [Setting Side Navigation](https://github.com/adobe/aio-theme#side-navigation)
+- [Using assets](https://github.com/adobe/aio-theme#assets)
+- [Configuring global navigation](https://github.com/adobe/aio-theme#global-navigation)
+- [Configuring side navigation](https://github.com/adobe/aio-theme#side-navigation)
 - [Using content blocks](https://github.com/adobe/aio-theme#jsx-blocks)
-- [Notes on using Markdown](https://github.com/adobe/aio-theme#writing-enhanced-markdown)
+- [Writing enhanced Markdown](https://github.com/adobe/aio-theme#writing-enhanced-markdown)
+- [Deploying the site](https://github.com/adobe/aio-theme#deploy-to-azure-storage-static-websites) _(Adobe employees only)_
 
-For more in-depth [instructions](https://github.com/adobe/aio-theme#getting-started).
-
-## How to deploy
-
-For any team that wishes to deploy to the adobe.io and stage.adobe.io website, they must be in contact with the dev-site team. Teams will be given a path that will follow the pattern `adobe.io/{product}/`. This will allow doc developers to setup their subpaths to look something like:
-```
-adobe.io/{product}/docs
-adobe.io/{product}/community
-adobe.io/{product}/community/code_of_conduct
-adobe.io/{product}/community/contribute
-```
-
-### Launching a deploy
-
-You can deploy using the GitHub actions deploy workflow see [deploy instructions](https://github.com/adobe/aio-theme#deploy-to-azure-storage-static-websites).
+If you have questions, open an issue and ask us. We look forward to hearing from you!


### PR DESCRIPTION
This pull request (PR) standardizes the README using the [magento/devdocs](https://github.com/magento/devdocs/blob/master/README.md?plain=1) repo as a baseline. The goal is to have a standard README that can be used across all [`commerce-*`](https://github.com/topics/adobe-commerce-devsite) devsite repos and add repo-specific info if necessary (e.g., generating API reference, rendering templates).