### PR TITLE
Added hint for MacOS users

### DIFF
--- a/src/pages/guide/static/analysis.md
+++ b/src/pages/guide/static/analysis.md
@@ -34,6 +34,10 @@ The ESLint rules are set up in `magento-coding-standard`, which is installed on 
 1. Enter the path to your ESLint package: `[magento_root]/node_modules/eslint`
 1. Click **Configuration File** and in the adjacent input field enter the path to the ESLint file the application uses, which is located in `vendor/magento/magento-coding-standard/eslint/.eslintrc-magento`.
 
+<InlineAlert variant="info" slots="text" />
+
+For MacOS system you may not be able to choose file with leading dot. You can rename this config file: `cp vendor/magento/magento-coding-standard/eslint/.eslintrc-magento vendor/magento/magento-coding-standard/eslint/eslintrc-magento`
+
 See the image below for example configuration:
 
 ![ESLint](../../_images/guide/static-eslint.png)

--- a/src/pages/guide/static/analysis.md
+++ b/src/pages/guide/static/analysis.md
@@ -36,7 +36,7 @@ The ESLint rules are set up in `magento-coding-standard`, which is installed on 
 
 <InlineAlert variant="info" slots="text" />
 
-For MacOS system you may not be able to choose file with leading dot. You can rename this config file: `cp vendor/magento/magento-coding-standard/eslint/.eslintrc-magento vendor/magento/magento-coding-standard/eslint/eslintrc-magento`
+On MacOS systems, you may not be able to choose a file with a leading dot. You can rename the configuration file and remove the dot: `cp vendor/magento/magento-coding-standard/eslint/.eslintrc-magento vendor/magento/magento-coding-standard/eslint/eslintrc-magento`
 
 See the image below for example configuration:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a hint for MacOS users to the "How to configure eslint" doc.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

https://developer.adobe.com/commerce/testing/guide/static/analysis/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->



<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-testing/blob/main/.github/CONTRIBUTING.md) for more information.
-->
