### PR TITLE
ACQE-5463: Document AllowList for TestDependency

### DIFF
--- a/src/pages/functional-testing-framework/commands/mftf.md
+++ b/src/pages/functional-testing-framework/commands/mftf.md
@@ -601,7 +601,7 @@ Currently, the ruleset only defines the tests to run. Here is an example of the 
 
 #### Defining allow-list
 
-Some `static-checks` allow modules to define an `allow-list`, which instruct the static check to ignore specific errors and allow checks to pass.
+Some `static-checks` allow modules to define an `allow-list`, which instructs the static check to ignore specific errors and allow checks to pass.
 All `allow-list` files must be placed in the root of the corresponding module's `Test/Mftf` folder.
 
 The following `static-checks` use `allow-list` files

--- a/src/pages/functional-testing-framework/commands/mftf.md
+++ b/src/pages/functional-testing-framework/commands/mftf.md
@@ -599,6 +599,14 @@ Currently, the ruleset only defines the tests to run. Here is an example of the 
 }
 ```
 
+#### Defining allow-list
+
+Some `static-checks` allow modules to define an `allow-list`, which instruct the static check to ignore specific errors and allow checks to pass.
+All `allow-list` files must be placed in the root of the corresponding module's `Test/Mftf` folder.
+
+The following `static-checks` use `allow-list` files
+-   `testDependencies` as `test-dependency-allowlist`
+
 ### `upgrade:tests`
 
 When the path argument is specified, this `upgrade` command applies all the major version Functional Testing Framework upgrade scripts to a `Test Module` in the given path.

--- a/src/pages/functional-testing-framework/commands/mftf.md
+++ b/src/pages/functional-testing-framework/commands/mftf.md
@@ -604,7 +604,8 @@ Currently, the ruleset only defines the tests to run. Here is an example of the 
 Some `static-checks` allow modules to define an `allow-list`, which instructs the static check to ignore specific errors and allow checks to pass.
 All `allow-list` files must be placed in the root of the corresponding module's `Test/Mftf` folder.
 
-The following `static-checks` use `allow-list` files
+The following `static-checks` use `allow-list` files:
+
 -   `testDependencies` as `test-dependency-allowlist`
 
 ### `upgrade:tests`


### PR DESCRIPTION


## Purpose of this pull request

- Add allowlist section to MFTF docs, as functionality changed and the check is going to be enabled by default in mainline PRs.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/testing/functional-testing-framework/commands/mftf/


<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-testing/blob/main/.github/CONTRIBUTING.md) for more information.
-->
