### PR TITLE
Update two-factor-authentication.md

### DIFF
--- a/src/pages/functional-testing-framework/two-factor-authentication.md
+++ b/src/pages/functional-testing-framework/two-factor-authentication.md
@@ -25,7 +25,7 @@ Now set the OTP window to `29`:
 
 <InlineAlert variant="info" slots="text" />
 
-The default OTP window is `1` in [2.4.7](https://experienceleague.adobe.com/docs/commerce-operations/release/notes/adobe-commerce/2-4-7.html).
+In [2.4.7](https://experienceleague.adobe.com/docs/commerce-operations/release/notes/adobe-commerce/2-4-7.html) and later, the OTP window configuration setting controls how long (in seconds) the system accepts an administrator's one-time-password (OTP) after it has expired. The system default is `1`.
 
 ```bash
 bin/magento config:set twofactorauth/google/otp_window 29

--- a/src/pages/functional-testing-framework/two-factor-authentication.md
+++ b/src/pages/functional-testing-framework/two-factor-authentication.md
@@ -25,7 +25,7 @@ Now set the OTP window to `29`:
 
 <InlineAlert variant="info" slots="text" />
 
-In [2.4.7](https://experienceleague.adobe.com/docs/commerce-operations/release/notes/adobe-commerce/2-4-7.html) and later, the OTP window configuration setting controls how long (in seconds) the system accepts an administrator's one-time-password (OTP) after it has expired. The system default is `1`.
+In [2.4.7](https://experienceleague.adobe.com/docs/commerce-operations/release/notes/adobe-commerce/2-4-7.html) and later, the OTP window configuration setting controls how long (in seconds) the system accepts an administrator's one-time-password (OTP) after it has expired. This value must be less than 30 seconds. The system default is `1`.
 
 ```bash
 bin/magento config:set twofactorauth/google/otp_window 29


### PR DESCRIPTION
Add explanation of OTP window setting for 2.4.7 and later.

## Purpose of this pull request

Updates the note to describe behavior of OTP window configuration setting in 2.4.7 and later releases.

## Affected pages

[Configuring two-factor authentication (2FA)](https://developer.adobe.com/commerce/testing/functional-testing-framework/two-factor-authentication/)

## Links to Magento Open Source code

Issue report: https://github.com/magento/magento2/issues/38597

