### PR TITLE
Replace links to decommissioned resources

### DIFF
--- a/src/pages/functional-testing-framework/cicd.md
+++ b/src/pages/functional-testing-framework/cicd.md
@@ -116,6 +116,6 @@ allure generate <path_to_results> -c -o <path_to_output>
 ```
 
 <!-- Link definitions -->
-[Install Commerce using Composer]: https://devdocs.magento.com/guides/v2.4/install-gde/composer.html
+[Install Commerce using Composer]: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/composer
 [Configure 2FA]: two-factor-authentication.md
 [Allure]: https://docs.qameta.io/allure/

--- a/src/pages/functional-testing-framework/data.md
+++ b/src/pages/functional-testing-framework/data.md
@@ -342,6 +342,6 @@ Attributes|Type|Use|Description
 [`<required-entities>`]: #requiredentity
 [`<var>`]: #var
 [Actions]: test/actions.md
-[category creation]: https://docs.magento.com/user-guide/catalog/category-create.html
+[category creation]: https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/categories/create/category-create
 [Credentials]: credentials.md
 [test actions]: test/actions.md#actions-returning-a-variable

--- a/src/pages/functional-testing-framework/getting-started.md
+++ b/src/pages/functional-testing-framework/getting-started.md
@@ -362,12 +362,12 @@ allure serve dev/tests/_output/allure-results/
 [install Allure]: https://github.com/allure-framework/allure2#download
 [java]: https://www.oracle.com/java/technologies/downloads/
 [tests]: index.md#tests
-[php]: https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements.html
+[php]: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
 [PhpStorm]: https://www.jetbrains.com/phpstorm/
 [selenium server]: https://www.seleniumhq.org/download/
 [Set up a standalone MFTF]: #set-up-a-standalone-mftf
 [test suite]: suite.md
 [Find your version]: index.md#find-your-framework-version
-[Installation Guide docroot]: https://devdocs.magento.com/guides/v2.4/install-gde/tutorials/change-docroot-to-pub.html
-[two-factor authentication (2FA) extension]: https://devdocs.magento.com/guides/v2.4/security/two-factor-authentication.html
+[Installation Guide docroot]: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/tutorials/docroot
+[two-factor authentication (2FA) extension]: https://developer.adobe.com/commerce/testing/functional-testing-framework/two-factor-authentication/
 [Credentials Page]: credentials.md

--- a/src/pages/functional-testing-framework/git-vs-composer-install.md
+++ b/src/pages/functional-testing-framework/git-vs-composer-install.md
@@ -85,7 +85,7 @@ If you are a contributing developer with an understanding of Git and Composer co
 
 <!-- Link definitions -->
 
-[Composer based Installation]: https://devdocs.magento.com/guides/v2.3/install-gde/composer.html
-[GitHub Installation]: https://devdocs.magento.com/guides/v2.3/install-gde/prereq/dev_install.html
+[Composer based Installation]: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/composer
+[GitHub Installation]: https://developer.adobe.com/commerce/contributor/guides/install/clone-repository/
 [Standalone]: getting-started.md#set-up-a-standalone-mftf
-[composer package]: https://devdocs.magento.com/guides/v2.3/extension-dev-guide/package/package_module.html
+[composer package]: https://developer.adobe.com/commerce/php/development/package/component/

--- a/src/pages/functional-testing-framework/index.md
+++ b/src/pages/functional-testing-framework/index.md
@@ -11,7 +11,7 @@ The Functional Testing Framework is a framework used to perform automated end-to
 
 <InlineAlert variant="info" slots="text"/>
 
-This documentation is for version 3.0 of the framework, which was released in conjunction with Adobe Commerce and Magento Open Source 2.4. It is a major update and introduces many new changes and fixes. You can find documentation for version 2.0 [here](https://devdocs.magento.com/mftf/v2/docs/introduction.html). See [find your version](#find-your-framework-version) if you are unsure about which version you are using.
+This documentation is for version 3.0 of the framework, which was released in conjunction with Adobe Commerce and Magento Open Source 2.4. It is a major update and introduces many new changes and fixes. You can find documentation for version 2.0 [here](https://github.com/magento/magento2-functional-testing-framework/blob/2.x-develop/docs/introduction.md). See [find your version](#find-your-framework-version) if you are unsure about which version you are using.
 
 ## Goals
 

--- a/src/pages/functional-testing-framework/metadata.md
+++ b/src/pages/functional-testing-framework/metadata.md
@@ -722,7 +722,7 @@ Example:
 <!-- LINK DEFINITIONS -->
 
 [actions]: test/actions.md
-[api reference]: https://devdocs.magento.com/guides/v2.4/get-started/bk-get-started-api.html
+[api reference]: https://developer.adobe.com/commerce/webapi/get-started/
 [application/x-www-form-urlencoded]: https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1
 [catalogCategoryRepositoryV1 image]: ../_images/functional-testing/catalogCategoryRepository-operations.png
 [createData]: test/actions.md#createdata
@@ -730,5 +730,5 @@ Example:
 [entity]: data.md#entity
 [getData]: test/actions.md#getdata
 [HTML forms]: https://www.w3.org/TR/html401/interact/forms.html
-[oauth]: https://devdocs.magento.com/guides/v2.4/get-started/authentication/gs-authentication-oauth.html
+[oauth]: https://developer.adobe.com/commerce/webapi/get-started/authentication/gs-authentication-oauth/
 [updateData]: test/actions.md#updatedata

--- a/src/pages/functional-testing-framework/test-writing/test-prep.md
+++ b/src/pages/functional-testing-framework/test-writing/test-prep.md
@@ -406,8 +406,8 @@ A well written test will end up being a set of action groups.
 The finished test is fully abstracted in such a way that it is short and readable and importantly, the abstracted data and action groups can be used again.
 
 <!-- Link Definitions -->
-[actions]: https://devdocs.magento.com/mftf/docs/test/actions.html
-[action groups]: https://devdocs.magento.com/mftf/docs/test/action-groups.html
-[Data entities]: https://devdocs.magento.com/mftf/docs/data.html
-[Input testing data]: https://devdocs.magento.com/mftf/docs/data.html
-[parameterized selectors]: https://devdocs.magento.com/mftf/docs/section/parameterized-selectors.html
+[actions]: https://developer.adobe.com/commerce/testing/functional-testing-framework/test/actions/
+[action groups]: https://developer.adobe.com/commerce/testing/functional-testing-framework/test/action-groups/
+[Data entities]: https://developer.adobe.com/commerce/testing/functional-testing-framework/data/
+[Input testing data]: https://developer.adobe.com/commerce/testing/functional-testing-framework/data/
+[parameterized selectors]: https://developer.adobe.com/commerce/testing/functional-testing-framework/section/parameterized-selectors/

--- a/src/pages/functional-testing-framework/test/actions.md
+++ b/src/pages/functional-testing-framework/test/actions.md
@@ -617,7 +617,7 @@ Delete the entity that was previously created using [`createData`](#createdata) 
 
 #### Example of existing data deletion
 
-Delete an entity using [REST API](https://devdocs.magento.com/redoc/2.3/) request to the corresponding route:
+Delete an entity using [REST API](https://developer.adobe.com/commerce/webapi/rest/) request to the corresponding route:
 
 ```xml
 <grabFromCurrentUrl regex="/^.+id\/([\d]+)/" stepKey="grabId"/>

--- a/src/pages/guide/integration/index.md
+++ b/src/pages/guide/integration/index.md
@@ -110,7 +110,7 @@ return [
 Leave all the settings that do not start with `db-` and `amqp-` at their default values.
 
 You can include additional setup options—available to the `setup:install` command—in the test configuration file. A
-complete list of options is available [here](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli.html).
+complete list of options is available [here](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/advanced).
 
 If your project requires custom entries in the `core_config_data` table, such as the introduction of new third-party services
 that affect your application on a basic level or configuration for logic that would prevent access if not configured

--- a/src/pages/guide/unit/writing-testable-code.md
+++ b/src/pages/guide/unit/writing-testable-code.md
@@ -38,7 +38,7 @@ This rule applies only to production code. When writing [integration tests][inte
 
 Whenever an external class property, class constant, or a class method is used in a file, this file depends on the class containing the method or constant. Even if the external class is not used as an instantiated object, the current class is still hard-wired to depend on it.
 
-[PHP] cannot execute the code unless it can load the external class, too. That is why such external classes are referred to as *dependencies*. Try to keep the number of dependencies to a minimum.
+PHP cannot execute the code unless it can load the external class, too. That is why such external classes are referred to as *dependencies*. Try to keep the number of dependencies to a minimum.
 
 Collaborator instances should be passed into the class using [constructor injection][constructor-injection].
 
@@ -292,7 +292,6 @@ Almost as a side effect, those classes are very easy to test.
 [single-responsibility-principle]: https://en.wikipedia.org/wiki/Single_responsibility_principle
 [generated]: https://developer.adobe.com/commerce/php/development/components/code-generation/
 [integration-tests]: ../integration/index.md
-[PHP]: https://glossary.magento.com/php
 [constructor-injection]: https://developer.adobe.com/commerce/php/development/components/dependency-injection/
 [IoInterface]: https://github.com/magento/magento2/blob/2.4/lib/internal/Magento/Framework/Filesystem/Io/IoInterface.php
 [DateTimeInterface]: https://www.php.net/manual/en/refs.calendar.php


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replace links to decommissioned resources with up-todate-links.

## Affected pages

- https://developer.adobe.com/commerce/testing//functional-testing-framework/cicd/
- https://developer.adobe.com/commerce/testing//functional-testing-framework/data/
- https://developer.adobe.com/commerce/testing//functional-testing-framework/getting-started/
- https://developer.adobe.com/commerce/testing//functional-testing-framework/git-vs-composer-install/
- https://developer.adobe.com/commerce/testing//functional-testing-framework/
- https://developer.adobe.com/commerce/testing//functional-testing-framework/metadata/
- https://developer.adobe.com/commerce/testing//functional-testing-framework/test-writing/test-prep/
- https://developer.adobe.com/commerce/testing//functional-testing-framework/test/actions/
- https://developer.adobe.com/commerce/testing//guide/integration/
- https://developer.adobe.com/commerce/testing//guide/unit/writing-testable-code/