### PR TITLE
Added CLI Command run with PHPUnit 10 

### DIFF
--- a/src/pages/guide/unit/command-line.md
+++ b/src/pages/guide/unit/command-line.md
@@ -92,9 +92,7 @@ Add the following line in the `<php>` block to disable the PHP memory limit duri
 
 ### CLI Command run with PHPUnit 10
 
-If you encounter an error similar to `Bootstrapping of extension Qameta\Allure\PHPUnit\AllureExtension failed: Config file allure/allure.config.php doesn't exist`, follow these steps to resolve it.
-
-To resolve this issue and successfully execute unit tests, follow the steps outlined below:
+If you encounter an error similar to `Bootstrapping of extension Qameta\Allure\PHPUnit\AllureExtension failed: Config file allure/allure.config.php doesn't exist`, follow the steps below to resolve it and run your unit tests successfully.
 
 #### Steps to Run Tests via CLI:
 

--- a/src/pages/guide/unit/command-line.md
+++ b/src/pages/guide/unit/command-line.md
@@ -13,9 +13,20 @@ keywords:
 
 To run all tests, navigate to the application root directory and execute the following command:
 
+*  earlier v2.4.7:
+
 ```bash
-cd dev/tests/unit/
-./../../../vendor/bin/phpunit -c phpunit.xml.dist
+./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist
+```
+
+*  since v2.4.8:
+
+```bash
+cd dev/tests/integration
+```
+
+```bash
+../../../vendor/bin/phpunit -c phpunit.xml.dist
 ```
 
 ## Run only a subset of the unit tests
@@ -24,9 +35,20 @@ To run only tests within a specific directory branch, all you have to do is to s
 
 The following example tells PHPUnit to look for any file ending with `Test.php` within the directory branch `app/code/Example/Module/Test/Unit` and try to execute it.
 
+*  earlier v2.4.7 running PHPUnit 9:
+
 ```bash
-cd dev/tests/unit/
-./../../../vendor/bin/phpunit -c phpunit.xml.dist ./../../../app/code/Example/Module/Test/Unit
+./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Example/Module/Test/Unit
+```
+
+*  since v2.4.8 running PHPUnit 10 from the `dev/tests/integration` directory:
+
+```bash
+cd dev/tests/integration
+```
+
+```bash
+../../../vendor/bin/phpunit -c phpunit.xml.dist ../../../app/code/Example/Module/Test/Unit
 ```
 
 ## Explanation

--- a/src/pages/guide/unit/command-line.md
+++ b/src/pages/guide/unit/command-line.md
@@ -14,7 +14,8 @@ keywords:
 To run all tests, navigate to the application root directory and execute the following command:
 
 ```bash
-./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist
+cd dev/tests/unit/
+./../../../vendor/bin/phpunit -c phpunit.xml.dist
 ```
 
 ## Run only a subset of the unit tests
@@ -24,7 +25,8 @@ To run only tests within a specific directory branch, all you have to do is to s
 The following example tells PHPUnit to look for any file ending with `Test.php` within the directory branch `app/code/Example/Module/Test/Unit` and try to execute it.
 
 ```bash
-./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Example/Module/Test/Unit
+cd dev/tests/unit/
+./../../../vendor/bin/phpunit -c phpunit.xml.dist ./../../../app/code/Example/Module/Test/Unit
 ```
 
 ## Explanation

--- a/src/pages/guide/unit/command-line.md
+++ b/src/pages/guide/unit/command-line.md
@@ -13,20 +13,8 @@ keywords:
 
 To run all tests, navigate to the application root directory and execute the following command:
 
-*  earlier v2.4.7 running PHPUnit 9:
-
 ```bash
 ./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist
-```
-
-*  since v2.4.8 running PHPUnit 10 from the `dev/tests/integration` directory:
-
-```bash
-cd dev/tests/integration
-```
-
-```bash
-../../../vendor/bin/phpunit -c phpunit.xml.dist
 ```
 
 ## Run only a subset of the unit tests
@@ -35,20 +23,8 @@ To run only tests within a specific directory branch, all you have to do is to s
 
 The following example tells PHPUnit to look for any file ending with `Test.php` within the directory branch `app/code/Example/Module/Test/Unit` and try to execute it.
 
-*  earlier v2.4.7 running PHPUnit 9:
-
 ```bash
 ./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Example/Module/Test/Unit
-```
-
-*  since v2.4.8 running PHPUnit 10 from the `dev/tests/integration` directory:
-
-```bash
-cd dev/tests/integration
-```
-
-```bash
-../../../vendor/bin/phpunit -c phpunit.xml.dist ../../../app/code/Example/Module/Test/Unit
 ```
 
 ## Explanation
@@ -113,3 +89,23 @@ Add the following line in the `<php>` block to disable the PHP memory limit duri
 ```xml
 <ini name="memory_limit" value="-1"/>
 ```
+
+### CLI Command run with PHPUnit 10
+
+If you encounter an error similar to `Bootstrapping of extension Qameta\Allure\PHPUnit\AllureExtension failed: Config file allure/allure.config.php doesn't exist`, follow these steps to resolve it.
+
+To resolve this issue and successfully execute unit tests, follow the steps outlined below:
+
+#### Steps to Run Tests via CLI:
+
+1. Navigate to the unit test directory
+   From the project root, execute the following command to change into the unit test directory:
+   ```bash
+   cd dev/tests/unit/
+   ```
+
+2. Run PHPUnit
+   Use the following command to execute PHPUnit with the appropriate configuration:
+   ```bash
+   ../../../vendor/bin/phpunit -c phpunit.xml.dist ../../../app/code/Example/Module/Test/Unit
+   ```

--- a/src/pages/guide/unit/command-line.md
+++ b/src/pages/guide/unit/command-line.md
@@ -13,13 +13,13 @@ keywords:
 
 To run all tests, navigate to the application root directory and execute the following command:
 
-*  earlier v2.4.7:
+*  earlier v2.4.7 running PHPUnit 9:
 
 ```bash
 ./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist
 ```
 
-*  since v2.4.8:
+*  since v2.4.8 running PHPUnit 10 from the `dev/tests/integration` directory:
 
 ```bash
 cd dev/tests/integration


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the Config file allure/allure.config.php doesn't exist issue.

run command:
./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist

(doc: https://developer.adobe.com/commerce/testing/guide/unit/command-line/)

Error: Config file allure/allure.config.php doesn't exist

[GitHub Issue Ref] : (https://github.com/magento/magento2/issues/36702#issuecomment-2358670590)

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-testing/blob/main/.github/CONTRIBUTING.md) for more information.
-->
