### PR TITLE
Upgrade actions/cache in the GitHub workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           cache-dependency-path: 'yarn.lock'
   
       - name: Gatsby Cache
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v4
         with:
           path: |
             public

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -74,7 +74,7 @@
             cache-dependency-path: 'yarn.lock'
   
         - name: Gatsby Cache
-          uses: actions/cache@v3.3.2
+          uses: actions/cache@v4
           with:
             path: |
               public


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) upgrades actions/cache in the staging and publishing workflows to fix the deprecation issue.

Green run on staging: [here](https://github.com/AdobeDocs/commerce-testing/actions/runs/13399784466)
