### PR TITLE
Update GH Pages workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -5,9 +5,6 @@ permissions: {}
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Use Setup Node and Install Dependencies Action
@@ -38,14 +35,24 @@ jobs:
         uses: actions/upload-pages-artifact@v3 # or specific "vX.X.X" version tag for this action
         with:
           path: public
-  # Deployment job
+  # Deploy job
   deploy:
+    # Add a dependency to the build job
+    needs: build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -3,7 +3,7 @@ name: Github Pages
 on: workflow_dispatch
 permissions: {}
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -17,6 +17,7 @@ jobs:
           cache-dependency-path: 'yarn.lock'
 
       - name: Build site
+        id: build
         run: yarn build
         env:
           NODE_OPTIONS: "--max-old-space-size=8192"
@@ -32,14 +33,19 @@ jobs:
           GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
           GOOGLE_DOCS_TOKEN: ${{ secrets.GOOGLE_DOCS_TOKEN }}
           GOOGLE_DOCS_FOLDER_ID: ${{ secrets.GOOGLE_DOCS_FOLDER_ID }}
-      - name: Deploy to GH Pages
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Upload static files as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3 # or specific "vX.X.X" version tag for this action
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages # The branch the action should deploy to.
-          folder: public # The folder the action should deploy.
-          clean: true # Automatically remove deleted files from deploy branch
-      - name: GH Pages URL
-        id: gh-pages-url
-        run: |
-          echo "View GH-Pages: $(https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }})"
+          path: public
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the github-pages workflow to use [native actions](https://github.com/actions/deploy-pages) for deployment.
This allows to improve maintenance by eliminating dependency on the implementation and support of individual contributors as well as to use GitHub Actions without gh-pages branch. The latter becomes essential when using a local setup with several remotes where each remote has gh-pages with different git history.
Additionally, this implementation enables [environment protection](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment) settings if needed.

Successful test run [here](https://github.com/commerce-docs/commerce-testing/actions/runs/13402303254).