### PR TITLE
Remove MFTF Compatibility Table

### DIFF
--- a/src/pages/functional-testing-framework/versioning.md
+++ b/src/pages/functional-testing-framework/versioning.md
@@ -61,18 +61,3 @@ It MAY include patch level changes. Patch version MUST be reset to 0 when minor 
 Major version **X** MUST be incremented for a release that introduces backward incompatible changes.
 A major release can also include minor and patch level changes.
 You must reset the patch and minor version to 0 when you change the major version.
-
-## Commerce compatibility
-
-This table lists the version of the Functional Testing Framework that was released with a particular version of Adobe Commerce or Magento Open Source.
-
-|Commerce version| Framework  version|
-|---    |---     |
-| 2.4.0 | 3.0.0  |
-| 2.3.5 | 2.6.4  |
-| 2.3.4 | 2.5.3  |
-| 2.3.3 | 2.4.5  |
-| 2.3.2 | 2.3.14 |
-| 2.3.1 | 2.3.13 |
-| 2.3.0 | 2.3.9  |
-| 2.2.8 | 2.3.13 |


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the versioning table from MFTF Devdocs

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/testing/functional-testing-framework/versioning/

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-testing/blob/main/.github/CONTRIBUTING.md) for more information.
-->
